### PR TITLE
Propagate selections 'mark as seen' and 'mark as unseen'

### DIFF
--- a/resources/lib/api_simkl.py
+++ b/resources/lib/api_simkl.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 import sys
 import json
@@ -19,7 +19,6 @@ from resources.lib.utils import __addon__
 REDIRECT_URI = "http://simkl.com"
 APIKEY = '62a587ec2a82dbed02c6ab48b923d72e775cb1096d2de60d04502413e36ef100'
 SECRET = '3e9d1563659a94a930c282d3d38cc01ece2ab5d769ae449cff1ff6f13d9b732e'
-
 
 class Simkl:
     def __init__(self):
@@ -131,6 +130,43 @@ class Simkl:
         log("Send: {0}".format(json.dumps(s_data)))
         while True and s_data:
             r = self._http("/sync/history/", body=json.dumps(s_data), headers=self.headers)
+            if r is None: return False
+            break
+        return True
+
+    def mark_as_unwatched(self, item):
+        if not item: return False
+
+        log("UNMARK: {0}".format(item))
+
+        s_data = {}
+        if item["type"] == "shows":
+            # TESTED
+            s_data[item["type"]] = [{
+                "title": item["title"],
+                "ids": item['ids'],
+                "seasons": [{
+                    "number": item['season'],
+                    "episodes": [{
+                        "number": item['episode']
+                    }]
+                }]
+            }]
+        elif item["type"] == "movies":
+            _prep = {
+                "title": item["title"],
+                "year": item["year"],
+            }
+            if "simkl" in item:
+                _prep["ids"] = {"simkl": item["simkl"]}
+            elif "ids" in item:
+                _prep["ids"] = item['ids']
+
+            s_data[item["type"]] = [_prep]
+
+        log("Send: {0}".format(json.dumps(s_data)))
+        while True and s_data:
+            r = self._http("/sync/history/remove", body=json.dumps(s_data), headers=self.headers)
             if r is None: return False
             break
         return True

--- a/resources/lib/events.py
+++ b/resources/lib/events.py
@@ -1,4 +1,5 @@
 import xbmc
+import json
 
 from resources.lib.utils import log
 
@@ -12,6 +13,79 @@ class Monitor(xbmc.Monitor):
     def onNotification(self, sender, method, data):
         log('onNotification')
         log('sender {0}'.format(bool(sender == 'script.simkl')))
+
+        if (method == 'VideoLibrary.OnUpdate'):
+            params = json.loads(data)
+            _item = params.get('item')
+            if _item and _item.get('type') and _item.get('id') and 'playcount' in params:
+                ptype = _item['type']
+                pid = _item['id']
+                playcount = params.get('playcount')
+
+                mitem = {}
+                mitem['ids'] = {}
+                mitem_valid = False
+                if ptype == 'episode':
+                    while True:
+                        episodeid = pid
+                        _response = json.loads(xbmc.executeJSONRPC(json.dumps({
+                            'jsonrpc': '2.0',
+                            'method': 'VideoLibrary.GetEpisodeDetails',
+                            'params': {'episodeid': episodeid,
+                                       'properties': ['tvshowid', 'showtitle', 'season', 'episode']},
+                            'id': 1})))
+                        episodedetails = _response.get('result', {}).get('episodedetails')
+                        if not episodedetails:
+                            log('failed response episodedetails: {0}'.format(_response))
+                            break
+                        _response = json.loads(xbmc.executeJSONRPC(json.dumps({
+                            'jsonrpc': '2.0',
+                            'method': 'VideoLibrary.GetTVShowDetails',
+                            'params': {'tvshowid': episodedetails['tvshowid'],
+                                       'properties': ['uniqueid']},
+                            'id': 1})))
+                        tvshowdetails = _response.get('result', {}).get('tvshowdetails')
+                        if not tvshowdetails:
+                            log('failed response tvshowdetails: {0}'.format(_response))
+                            break
+                        mitem['type'] = 'shows'
+                        mitem['title'] = episodedetails['showtitle']
+                        mitem['season'] = episodedetails['season']
+                        mitem['episode'] = episodedetails['episode']
+                        if tvshowdetails["uniqueid"].get("tvdb"): mitem["ids"]["tvdb"] = tvshowdetails["uniqueid"]["tvdb"]
+                        if tvshowdetails["uniqueid"].get("tmdb"): mitem["ids"]["tmdb"] = tvshowdetails["uniqueid"]["tmdb"]
+                        mitem_valid = True
+                        break
+                elif ptype == 'movie':
+                    while True:
+                        movieid = pid
+                        _response = json.loads(xbmc.executeJSONRPC(json.dumps({
+                            'jsonrpc': '2.0',
+                            'method': 'VideoLibrary.GetMovieDetails',
+                            'params': {'movieid': movieid,
+                                       'properties': ['title', 'year', 'uniqueid']},
+                            'id': 1})))
+                        moviedetails = _response.get('result', {}).get('moviedetails')
+                        if not moviedetails:
+                            log('failed response moviedetails: {0}'.format(_response))
+                            break
+                        mitem['type'] = 'movies'
+                        mitem['title'] = moviedetails['title']
+                        mitem['year'] = moviedetails['year']
+                        if moviedetails["uniqueid"].get("tvdb"): mitem["ids"]["tvdb"] = moviedetails["uniqueid"]["tvdb"]
+                        if moviedetails["uniqueid"].get("tmdb"): mitem["ids"]["tmdb"] = moviedetails["uniqueid"]["tmdb"]
+                        if moviedetails["uniqueid"].get("imdb"): mitem["ids"]["imdb"] = moviedetails["uniqueid"]["imdb"]
+                        mitem_valid = True
+                        break
+                else:
+                    log('Unknown type {0}'.format(ptype))
+
+                if mitem_valid:
+                    if (playcount > 0): # If it has been watched
+                        self._api.mark_as_watched(mitem)
+                    else:
+                        self._api.mark_as_unwatched(mitem)
+
         if sender == "script.simkl":
             if method == 'Other.login':
                 self._api.login()


### PR DESCRIPTION
This feature sends sync/history and sync/history/remove nottifications to SIMKL, when "mark as seen" or "mark as unseen" is selected from the context menu.